### PR TITLE
default to service-type=LoadBalancer

### DIFF
--- a/lib/charms/observability_libs/v0/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_service_patch.py
@@ -12,7 +12,7 @@ When modifying the default set of resources managed by Juju, one must consider t
 charm. In this case, any modifications to the default service (created during deployment), will
 be overwritten during a charm upgrade.
 
-When intialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
+When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
 events which applies the patch to the cluster. This should ensure that the service ports are
 correct throughout the charm's life.
 
@@ -22,20 +22,26 @@ a port for the service, where each tuple contains:
 - a name for the port
 - port for the service to listen on
 - optionally: a targetPort for the service (the port in the container!)
+- optionally: a nodePort for the service (for NodePort or LoadBalancer services only!)
+- optionally: a name of the service (in case service name needs to be patched as well)
 
 ## Getting Started
 
 To get started using the library, you just need to fetch the library using `charmcraft`. **Note
-that you also need to add `lightkube` to your charm's `requirements.txt`.**
+that you also need to add `lightkube` and `lightkube-models` to your charm's `requirements.txt`.**
 
 ```shell
 cd some-charm
 charmcraft fetch-lib charms.observability_libs.v0.kubernetes_service_patch
-echo "lightkube" >> requirements.txt
+echo <<-EOF >> requirements.txt
+lightkube
+lightkube-models
+EOF
 ```
 
 Then, to initialise the library:
 
+For ClusterIP services:
 ```python
 # ...
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
@@ -44,6 +50,20 @@ class SomeCharm(CharmBase):
   def __init__(self, *args):
     # ...
     self.service_patcher = KubernetesServicePatch(self, [(f"{self.app.name}", 8080)])
+    # ...
+```
+
+For LoadBalancer/NodePort services:
+```python
+# ...
+from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.service_patcher = KubernetesServicePatch(
+        self, [(f"{self.app.name}", 443, 443, 30666)], "LoadBalancer"
+    )
     # ...
 ```
 
@@ -62,7 +82,8 @@ def setUp(self, *unused):
 """
 
 import logging
-from typing import List, Optional, Tuple
+from types import MethodType
+from typing import Literal, Sequence, Tuple, Union
 
 from lightkube import ApiError, Client
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
@@ -82,51 +103,116 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 6
+
+PortDefinition = Union[Tuple[str, int], Tuple[str, int, int], Tuple[str, int, int, int]]
+ServiceType = Literal["ClusterIP", "LoadBalancer"]
 
 
 class KubernetesServicePatch(Object):
     """A utility for patching the Kubernetes service set up by Juju."""
 
-    def __init__(self, charm: CharmBase, ports: List[Tuple[str, int, Optional[int]]]):
+    def __init__(
+        self,
+        charm: CharmBase,
+        ports: Sequence[PortDefinition],
+        service_name: str = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
+        additional_annotations: dict = None,
+    ):
         """Constructor for KubernetesServicePatch.
 
         Args:
             charm: the charm that is instantiating the library.
-            ports: a list of tuples (name, port, targetPort) for every service port.
+            ports: a list of tuples (name, port, targetPort, nodePort) for every service port.
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
         """
         super().__init__(charm, "kubernetes-service-patch")
         self.charm = charm
-        self.service = self._service_object(ports)
+        self.service_name = service_name if service_name else self._app
+        self.service = self._service_object(
+            ports,
+            service_name,
+            service_type,
+            additional_labels,
+            additional_selectors,
+            additional_annotations,
+        )
 
+        # Make mypy type checking happy that self._patch is a method
+        assert isinstance(self._patch, MethodType)
         # Ensure this patch is applied during the 'install' and 'upgrade-charm' events
         self.framework.observe(charm.on.install, self._patch)
         self.framework.observe(charm.on.upgrade_charm, self._patch)
 
-    def _service_object(self, ports: List[Tuple[str, int, Optional[int]]]) -> Service:
-        """Creates a valid Service representation for Alertmanager.
+    def _service_object(
+        self,
+        ports: Sequence[PortDefinition],
+        service_name: str = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
+        additional_annotations: dict = None,
+    ) -> Service:
+        """Creates a valid Service representation.
 
         Args:
-            ports: a list of tuples of the form (name, port) or (name, port, targetPort) for every
-                service port. If the 'targetPort' is omitted, it is assumed to be equal to 'port'.
+            ports: a list of tuples of the form (name, port) or (name, port, targetPort)
+                or (name, port, targetPort, nodePort) for every service port. If the 'targetPort'
+                is omitted, it is assumed to be equal to 'port', with the exception of NodePort
+                and LoadBalancer services, where all port numbers have to be specified.
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
 
         Returns:
             Service: A valid representation of a Kubernetes Service with the correct ports.
         """
+        if not service_name:
+            service_name = self._app
+        labels = {"app.kubernetes.io/name": self._app}
+        if additional_labels:
+            labels.update(additional_labels)
+        selector = {"app.kubernetes.io/name": self._app}
+        if additional_selectors:
+            selector.update(additional_selectors)
         return Service(
             apiVersion="v1",
             kind="Service",
             metadata=ObjectMeta(
                 namespace=self._namespace,
-                name=self._app,
-                labels={"app.kubernetes.io/name": self._app},
+                name=service_name,
+                labels=labels,
+                annotations=additional_annotations,  # type: ignore[arg-type]
             ),
             spec=ServiceSpec(
-                selector={"app.kubernetes.io/name": self._app},
+                selector=selector,
                 ports=[
-                    ServicePort(name=p[0], port=p[1], targetPort=p[2] if len(p) > 2 else p[1])
+                    ServicePort(
+                        name=p[0],
+                        port=p[1],
+                        targetPort=p[2] if len(p) > 2 else p[1],  # type: ignore[misc]
+                        nodePort=p[3] if len(p) > 3 else None,  # type: ignore[arg-type, misc]
+                    )
                     for p in ports
                 ],
+                type=service_type,
             ),
         )
 
@@ -141,7 +227,9 @@ class KubernetesServicePatch(Object):
 
         client = Client()
         try:
-            client.patch(Service, self._app, self.service, patch_type=PatchType.MERGE)
+            if self.service_name != self._app:
+                self._delete_and_create_service(client)
+            client.patch(Service, self.service_name, self.service, patch_type=PatchType.MERGE)
         except ApiError as e:
             if e.status.code == 403:
                 logger.error("Kubernetes service patch failed: `juju trust` this application.")
@@ -149,6 +237,13 @@ class KubernetesServicePatch(Object):
                 logger.error("Kubernetes service patch failed: %s", str(e))
         else:
             logger.info("Kubernetes service '%s' patched successfully", self._app)
+
+    def _delete_and_create_service(self, client: Client):
+        service = client.get(Service, self._app, namespace=self._namespace)
+        service.metadata.name = self.service_name  # type: ignore[attr-defined]
+        service.metadata.resourceVersion = service.metadata.uid = None  # type: ignore[attr-defined]   # noqa: E501
+        client.delete(Service, self._app, namespace=self._namespace)
+        client.create(service)
 
     def is_patched(self) -> bool:
         """Reports if the service patch has been applied.
@@ -158,11 +253,11 @@ class KubernetesServicePatch(Object):
         """
         client = Client()
         # Get the relevant service from the cluster
-        service = client.get(Service, name=self._app, namespace=self._namespace)
+        service = client.get(Service, name=self.service_name, namespace=self._namespace)
         # Construct a list of expected ports, should the patch be applied
         expected_ports = [(p.port, p.targetPort) for p in self.service.spec.ports]
         # Construct a list in the same manner, using the fetched service
-        fetched_ports = [(p.port, p.targetPort) for p in service.spec.ports]
+        fetched_ports = [(p.port, p.targetPort) for p in service.spec.ports]  # type: ignore[attr-defined]  # noqa: E501
         return expected_ports == fetched_ports
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pwgen
 rabbitmq-admin
 tenacity
 lightkube
+lightkube-models


### PR DESCRIPTION
RabbitMQ will typically be needed from outside of the K8S
cluster so always deploy it as a LoadBalancer.