### PR TITLE
Explicitly start epmd

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 RABBITMQ_CONTAINER = "rabbitmq"
 RABBITMQ_SERVER_SERVICE = "rabbitmq-server"
+EPMD_SERVICE = "epmd"
 RABBITMQ_COOKIE_PATH = "/var/lib/rabbitmq/.erlang.cookie"
 
 
@@ -170,6 +171,15 @@ class RabbitMQOperatorCharm(CharmBase):
                     "override": "replace",
                     "summary": "RabbitMQ Server",
                     "command": "rabbitmq-server",
+                    "startup": "enabled",
+                    "requires": [
+                        EPMD_SERVICE
+                    ],
+                },
+                EPMD_SERVICE: {
+                    "override": "replace",
+                    "summary": "Erlang EPM service",
+                    "command": "epmd -d",
                     "startup": "enabled",
                 },
             },

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -30,6 +30,7 @@ class TestCharm(unittest.TestCase):
         # so mock out for now
         # TODO: remove when implemeted
         self.harness.charm._amqp_bind_address = Mock(return_value="10.5.0.1")
+        self.maxDiff = None
 
     def test_action(self):
         action_event = Mock()
@@ -49,6 +50,13 @@ class TestCharm(unittest.TestCase):
                     "override": "replace",
                     "summary": "RabbitMQ Server",
                     "command": "rabbitmq-server",
+                    "startup": "enabled",
+                    "requires": ["epmd"],
+                },
+                "epmd": {
+                    "override": "replace",
+                    "summary": "Erlang EPM service",
+                    "command": "epmd -d",
                     "startup": "enabled",
                 },
             },


### PR DESCRIPTION
Start the epmd service as part of the pebble plan and ensure
that it starts prior to the RabbitMQ service.