### PR TITLE
Wait for unit to have bind address for peers

### DIFF
--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -30,6 +30,7 @@ class TestCharm(unittest.TestCase):
         # so mock out for now
         # TODO: remove when implemeted
         self.harness.charm._amqp_bind_address = Mock(return_value="10.5.0.1")
+        self.harness.charm._peers_bind_address = Mock(return_value="10.10.1.1")
         self.maxDiff = None
 
     def test_action(self):


### PR DESCRIPTION
Rabbit wont start up on recent versions of juju as the network
information is delayed until the relation is established in order to
provide the correct bind address information for the relation. The charm
uses the amqp relation for recording information into the
rabbitmq-env.conf file, but this should be the peer address as the
rabbit internal logic uses it to determine if it has seen this node or
not.

Change the address recorded in rabbitmq-env.conf from the amqp binding
address to the peers binding address. Additionally, wait until the peers
binding address exists before trying to process remote relations and
handle a 401 Unauthorized error from rabbit when the node is started but
the unit has yet to configure the operator user.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>