### PR TITLE
Fix logging lines

### DIFF
--- a/lib/charms/sunbeam_rabbitmq_operator/v0/amqp.py
+++ b/lib/charms/sunbeam_rabbitmq_operator/v0/amqp.py
@@ -257,13 +257,13 @@ class AMQPProvides(Object):
     def _on_amqp_relation_joined(self, event):
         """Handle AMQP joined."""
         logging.debug("RabbitMQAMQPProvides on_joined data={}"
-                      .format(event.relation.data))
+                      .format(event.relation.data[event.relation.app]))
         self.on.has_amqp_clients.emit()
 
     def _on_amqp_relation_changed(self, event):
         """Handle AMQP changed."""
         logging.debug("RabbitMQAMQPProvides on_changed data={}"
-                      .format(event.relation.data))
+                      .format(event.relation.data[event.relation.app]))
         # Validate data on the relation
         if self.username(event) and self.vhost(event):
             self.on.ready_amqp_clients.emit()


### PR DESCRIPTION
The logging lines are failing when trying to access
event.relation.data. This appears to be change in juju or ops.
This change logs the app data bag specifically as that is what
the methods are examining.